### PR TITLE
Update Package.swift to support Mint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,11 @@ import PackageDescription
 
 let package = Package(
     name: "GeneratePR",
+    products: [
+        .executable(
+            name: "GeneratePR",
+            targets: ["GeneratePR"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],

--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ OPTIONS:
 
 To learn more please use `--help` or visit `https://github.com/Mieraidihaimu/GeneratePR`
 
+## 🌱 Use with Mint
+
+1. Install [Mint](https://github.com/yonaskolb/Mint#installing)
+
+2. Run GeneratePR on the fly
+
+    ```sh
+    $ mint run Mieraidihaimu/GeneratePR@main ...
+    ```
+
+    or install the package locally
+
+    ```sh
+    $ mint install Mieraidihaimu/GeneratePR@main
+    🌱 Cloning GeneratePR main
+    🌱 Resolving package
+    🌱 Building package
+    🌱 Installed GeneratePR main
+    🌱 Linked GeneratePR main to ~/.mint/bin
+    🌱 ~/.mint/bin must be added to your $PATH if you wish to run this package outside of mint
+
+    $ type GeneratePR
+    GeneratePR is ~/.mint/bin/GeneratePR
+    ```
+
 ## 🌝 Contribute
 
 1. Fork it! 👀


### PR DESCRIPTION
When running with Mint, it shows an error message:

```sh
$ mint run Mieraidihaimu/GeneratePR@0.0.2 -h 
🌱 Cloning GeneratePR 0.0.2
🌱 Resolving package
🌱  Executable product not found in GeneratePR 0.0.2
```

According to https://github.com/yonaskolb/Mint#support, the Swift package requires an `executable` product type in the `products` list. This PR updates the Package.swift to add Mint support.

Tested with:

```sh
$ mint run bcylin/GeneratePR@mint
```