### PR TITLE
Fix Commit logs formatting issues

### DIFF
--- a/Sources/GeneratePR/CreatePRCommand.swift
+++ b/Sources/GeneratePR/CreatePRCommand.swift
@@ -56,10 +56,11 @@ struct CreatePRCommand: ParsableCommand {
 
         // 1. Get all the commit logs against the base branch
         let outputCommitLogs = ShellScripRunner.runShell(command: githubCommand.allCommits)
+        let formattedCommitLogs = CommitLogsFormatter.format(commitLogsOutput: outputCommitLogs)
 
         // 2. Generate full pr description
         let prDescription = CommandHelper.generateDescription(
-            issue: issue, prType: type, commitLogs: outputCommitLogs, extra: extra ?? ""
+            issue: issue, prType: type, commitLogs: formattedCommitLogs, extra: extra ?? ""
         )
 
         // 3. Push the working branch to remote origin. At the moment, `gh pr create` will not push branch to the server https://github.com/cli/cli/issues/1718. Thus, we need to manually push the working branch to origin

--- a/Sources/GeneratePR/Helper/CommitLogsFormatter.swift
+++ b/Sources/GeneratePR/Helper/CommitLogsFormatter.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by Mier on 06/11/2021.
+//
+
+import Foundation
+
+struct CommitLogsFormatter {
+    private static let linePrefixCharacter = "- "
+    private static let lineBreak = "\n"
+
+    static func format(commitLogsOutput output: String) -> String {
+        output
+            .split(separator: lineBreak)
+            .map { formatLineIfNeeded($0) }
+            .joined(separator: lineBreak)
+    }
+
+
+    private static func formatLineIfNeeded(_ line: String) -> String {
+        guard line.prefix(2) != linePrefixCharacter else { return line }
+        return linePrefixCharacter + line.localizedCapitalized
+    }
+}

--- a/Sources/GeneratePR/Helper/CommitLogsFormatter.swift
+++ b/Sources/GeneratePR/Helper/CommitLogsFormatter.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  CommitLogsFormatter.swift
 //  
 //
 //  Created by Mier on 06/11/2021.
@@ -9,18 +9,22 @@ import Foundation
 
 struct CommitLogsFormatter {
     private static let linePrefixCharacter = "- "
-    private static let lineBreak = "\n"
+    private static let lineBreak: Character = "\n"
 
     static func format(commitLogsOutput output: String) -> String {
         output
             .split(separator: lineBreak)
-            .map { formatLineIfNeeded($0) }
-            .joined(separator: lineBreak)
+            .map { formatLineIfNeeded(String($0)) }
+            .joined(separator: String(lineBreak))
     }
 
 
     private static func formatLineIfNeeded(_ line: String) -> String {
         guard line.prefix(2) != linePrefixCharacter else { return line }
-        return linePrefixCharacter + line.localizedCapitalized
+        if #available(macOS 10.11, *) {
+            return linePrefixCharacter + line.localizedCapitalized
+        } else {
+            return linePrefixCharacter + line
+        }
     }
 }

--- a/Sources/GeneratePR/Helper/CommitLogsFormatter.swift
+++ b/Sources/GeneratePR/Helper/CommitLogsFormatter.swift
@@ -21,10 +21,6 @@ struct CommitLogsFormatter {
 
     private static func formatLineIfNeeded(_ line: String) -> String {
         guard line.prefix(2) != linePrefixCharacter else { return line }
-        if #available(macOS 10.11, *) {
-            return linePrefixCharacter + line.localizedCapitalized
-        } else {
-            return linePrefixCharacter + line
-        }
+        return linePrefixCharacter + line
     }
 }


### PR DESCRIPTION
# Related links

close https://github.com/Mieraidihaimu/GeneratePR/issues/13

# Why?

As pet ticket above, we need to fix the defect in this release.

# How?

Changes included:
- Add Commitlogsformatter Helper
- User Formatter To Have Pretty Printed Commits
- Fix Compiler Error :Joy



